### PR TITLE
Handle the case where the path to the configuration file is framed by quotes

### DIFF
--- a/encfs/encfs/FileUtils.cpp
+++ b/encfs/encfs/FileUtils.cpp
@@ -346,11 +346,21 @@ bool userAllowMkdir( const char *path, mode_t mode )
 ConfigType readConfig_load( ConfigInfo *nm, const char *path, 
 	const boost::shared_ptr<EncFSConfig> &config )
 {
+	char szConf2[255];
+	char *szConf = szConf2;
     if( nm->loadFunc )
     {
 	try
 	{
-	    if( (*nm->loadFunc)( path, config, nm ))
+		strcpy(szConf, path);
+		if (szConf[0]=='"') szConf+=1;
+		if (strlen(szConf)>0)
+		{
+			if (szConf[strlen(szConf)-1]=='"') szConf[strlen(szConf)-1]='\0';
+		}
+		rError( _("XFound config file %s, but failed to load"), szConf);
+
+	    if( (*nm->loadFunc)( szConf, config, nm ))
             {
                 config->cfgType = nm->type;
 		return nm->type;


### PR DESCRIPTION
Hi!

Currently, **ENCFS5_CONFIG/ENCFS6_CONFIG** environment variables
cannot be used in Windows to store **".encfs6.xml"** file separately from
the encrypted files. This patch handles the case.

In Windows the value of ENCFS5_CONFIG is always returned in double quotes
preventing to use it directly. The quotes must be removed before use.
Function readConfig_load() now checks if specified path is quoted and
removes the qoutes automatically.
